### PR TITLE
Add support for 7.5in 3-color panel.

### DIFF
--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -115,8 +115,10 @@ void setup()
     { // battery is now low for the first time
       prefs.putBool("lowBat", true);
       initDisplay();
-      drawError(battery_alert_0deg_196x196, "Low Battery", "");
-      display.display(false); // full display refresh
+      do
+      {
+        drawError(battery_alert_0deg_196x196, "Low Battery", "");
+      } while (display.nextPage());
       display.powerOff();
     }
 
@@ -165,14 +167,19 @@ void setup()
     if (wifiStatus == WL_NO_SSID_AVAIL)
     {
       Serial.println("SSID Not Available");
-      drawError(wifi_off_196x196, "SSID Not Available", "");
+      do
+      {
+        drawError(wifi_off_196x196, "SSID Not Available", "");
+      } while (display.nextPage());
     }
     else
     {
       Serial.println("WiFi Connection Failed");
-      drawError(wifi_off_196x196, "WiFi Connection", "Failed");
+      do
+      {
+        drawError(wifi_off_196x196, "WiFi Connection", "Failed");
+      } while (display.nextPage());
     }
-    display.display(false); // full display refresh
     display.powerOff();
     beginDeepSleep(startTime, &timeInfo);
   }
@@ -185,8 +192,10 @@ void setup()
     Serial.println("Failed To Fetch The Time");
     killWiFi();
     initDisplay();
-    drawError(wi_time_4_196x196, "Failed To Fetch", "The Time");
-    display.display(false); // full display refresh
+    do
+    {
+      drawError(wi_time_4_196x196, "Failed To Fetch", "The Time");
+    } while (display.nextPage());
     display.powerOff();
     beginDeepSleep(startTime, &timeInfo);
   }
@@ -203,8 +212,10 @@ void setup()
     tmpStr = String(rxOWM[0], DEC) + ": " + getHttpResponsePhrase(rxOWM[0]);
     killWiFi();
     initDisplay();
-    drawError(wi_cloud_down_196x196, statusStr, tmpStr);
-    display.display(false); // full display refresh
+    do
+    {
+      drawError(wi_cloud_down_196x196, statusStr, tmpStr);
+    } while (display.nextPage());
     display.powerOff();
     beginDeepSleep(startTime, &timeInfo);
   }
@@ -215,8 +226,10 @@ void setup()
     statusStr = "Air Pollution API";
     tmpStr = String(rxOWM[1], DEC) + ": " + getHttpResponsePhrase(rxOWM[1]);
     initDisplay();
-    drawError(wi_cloud_down_196x196, statusStr, tmpStr);
-    display.display(false); // full display refresh
+    do
+    {
+      drawError(wi_cloud_down_196x196, statusStr, tmpStr);
+    } while (display.nextPage());
     display.powerOff();
     beginDeepSleep(startTime, &timeInfo);
   }
@@ -252,14 +265,16 @@ void setup()
   getDateStr(dateStr, &timeInfo);
 
   initDisplay();
-  drawCurrentConditions(owm_onecall.current, owm_onecall.daily[0], 
-                        owm_air_pollution, inTemp, inHumidity);
-  drawForecast(owm_onecall.daily, timeInfo);
-  drawAlerts(owm_onecall.alerts, CITY_STRING, dateStr);
-  drawLocationDate(CITY_STRING, dateStr);
-  drawOutlookGraph(owm_onecall.hourly, timeInfo);
-  drawStatusBar(statusStr, refreshTimeStr, wifiRSSI, batteryVoltage);
-  display.display(false); // full display refresh
+  do
+  {
+    drawCurrentConditions(owm_onecall.current, owm_onecall.daily[0],
+                          owm_air_pollution, inTemp, inHumidity);
+    drawForecast(owm_onecall.daily, timeInfo);
+    drawAlerts(owm_onecall.alerts, CITY_STRING, dateStr);
+    drawLocationDate(CITY_STRING, dateStr);
+    drawOutlookGraph(owm_onecall.hourly, timeInfo);
+    drawStatusBar(statusStr, refreshTimeStr, wifiRSSI, batteryVoltage);
+  } while (display.nextPage());
   display.powerOff();
 
   // DEEP-SLEEP

--- a/platformio/src/renderer.cpp
+++ b/platformio/src/renderer.cpp
@@ -46,7 +46,7 @@ GxEPD2_BW<GxEPD2_750_T7, GxEPD2_750_T7::HEIGHT> display(
                 PIN_EPD_BUSY));    
 #endif
 #ifdef DISPLAY_3C
-GxEPD2_3C<GxEPD2_750c_Z08, GxEPD2_750c_Z08::HEIGHT> display(
+GxEPD2_3C<GxEPD2_750c_Z08, GxEPD2_750c_Z08::HEIGHT / 2> display(
   GxEPD2_750c_Z08(PIN_EPD_CS,
                   PIN_EPD_DC,
                   PIN_EPD_RST,

--- a/platformio/src/renderer.h
+++ b/platformio/src/renderer.h
@@ -10,9 +10,9 @@
 #define DISP_HEIGHT 480
 
 // B/W display
-#define DISPLAY_BW
+// #define DISPLAY_BW
 // 3-color display
-// #define DISPLAY_3C
+#define DISPLAY_3C
 
 #ifdef DISPLAY_BW
 #include <GxEPD2_BW.h>
@@ -20,7 +20,7 @@ extern GxEPD2_BW<GxEPD2_750_T7, GxEPD2_750_T7::HEIGHT> display;
 #endif
 #ifdef DISPLAY_3C
 #include <GxEPD2_3C.h>
-extern GxEPD2_3C<GxEPD2_750c_Z08, GxEPD2_750c_Z08::HEIGHT> display;
+extern GxEPD2_3C<GxEPD2_750c_Z08, GxEPD2_750c_Z08::HEIGHT / 2> display;
 #endif
 
 typedef enum alignment

--- a/platformio/src/renderer.h
+++ b/platformio/src/renderer.h
@@ -10,9 +10,9 @@
 #define DISP_HEIGHT 480
 
 // B/W display
-// #define DISPLAY_BW
+#define DISPLAY_BW
 // 3-color display
-#define DISPLAY_3C
+// #define DISPLAY_3C
 
 #ifdef DISPLAY_BW
 #include <GxEPD2_BW.h>


### PR DESCRIPTION
This PR adds support for 7.5in 3-color e-paper panels. To compile for 3-color panels, see the preprocessor macros at the top of renderer.h.

This closes issue #13.