### PR TITLE
When calculating max precipitation values, use first index too

### DIFF
--- a/platformio/src/renderer.cpp
+++ b/platformio/src/renderer.cpp
@@ -814,7 +814,7 @@ void drawOutlookGraph(owm_hourly_t *const hourly, tm timeInfo)
 #endif
   float tempMax = tempMin;
 #ifndef UNITS_PRECIP_POP
-  float precipMax = 0;
+  float precipMax = hourly[0].rain_1h + hourly[0].snow_1h;
 #endif
   int yTempMajorTicks = 5;
   float newTemp = 0;


### PR DESCRIPTION
Noticed that if the first index of rain values where larger than the rest, the bound calculation would be off,
as the loop below starts from 1.
I am not sure I understand why the first index does not need to be used for the temperature calculation though.