### PR TITLE
Put the low before the high.

### DIFF
--- a/platformio/src/renderer.cpp
+++ b/platformio/src/renderer.cpp
@@ -689,7 +689,7 @@ void drawForecast(owm_daily_t *const daily, tm timeInfo)
     drawString(x + 31 - 2, 98 + 69 / 2 - 32 - 26 - 6 + 16, dayBuffer, CENTER);
     timeInfo.tm_wday = (timeInfo.tm_wday + 1) % 7; // increment to next day
 
-    // high | low
+    // low | high
     display.setFont(&FONT_8pt8b);
     drawString(x + 31, 98 + 69 / 2 + 38 - 6 + 12, "|", CENTER);
 #ifdef UNITS_TEMP_KELVIN
@@ -712,8 +712,8 @@ void drawForecast(owm_daily_t *const daily, tm timeInfo)
                 std::round(kelvin_to_fahrenheit(daily[i].temp.min)))) +
             "\260";
 #endif
-    drawString(x + 31 - 4, 98 + 69 / 2 + 38 - 6 + 12, hiStr, RIGHT);
-    drawString(x + 31 + 5, 98 + 69 / 2 + 38 - 6 + 12, loStr, LEFT);
+    drawString(x + 31 - 4, 98 + 69 / 2 + 38 - 6 + 12, loStr, RIGHT);
+    drawString(x + 31 + 5, 98 + 69 / 2 + 38 - 6 + 12, hiStr, LEFT);
 
 // daily forecast precipitation
 #if DISPLAY_DAILY_PRECIP


### PR DESCRIPTION
It appears that when the OpenWeatherMap API returns its low temperature and high temperature for the day, that the low means that it's the lowest temperature expected in the 24 hour period that runs from midnight to midnight. That means that typically the low for Monday is the temperature on Monday at about 6 AM before the sun rises, and this low temperature comes before the high, which happens in the afternoon after the sun has been out all day. However, this display currently displays the low after the high, meaning that in the typical case, the low and high are not in chronological order.

By reversing the order, the high and low will more frequently be in chronological order, paralleling the way that most other weather forecasts report highs and lows.

Note: if tomorrow is forcasted to be much colder than today, and the weather pattern is going to dramatically cool off in the afternoon or overnight, then sometimes the low temperature returned by OpenWeatherMap will actually be at midnight at the end of the day. Hence, this new solution is only mostly chronological, but it should be chronological more often that the current way.