### PR TITLE
Improve support for unreliable networks

### DIFF
--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -298,6 +298,7 @@ extern const char *NTP_SERVER_1;
 extern const char *NTP_SERVER_2;
 extern const unsigned long NTP_TIMEOUT;
 extern const int SLEEP_DURATION;
+extern const int ERROR_SLEEP_DURATION;
 extern const int BED_TIME;
 extern const int WAKE_TIME;
 extern const int HOURLY_GRAPH_MAX;

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -121,6 +121,9 @@ const unsigned long NTP_TIMEOUT = 20000; // ms
 // Note: The OpenWeatherMap model is updated every 10 minutes, so updating more
 //       frequently than that is unnessesary.
 const int SLEEP_DURATION = 30; // minutes
+// Similar to above, this allows for a shorter duration for sleep after encountering
+// an error to allow for faster recovery in the case of an unreliable network.
+const int ERROR_SLEEP_DURATION = 5; // minutes
 // Bed Time Power Savings.
 // If BED_TIME == WAKE_TIME, then this battery saving feature will be disabled.
 // (range: [0-23])

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -46,16 +46,22 @@ Preferences prefs;
 /* Put esp32 into ultra low-power deep sleep (<11μA).
  * Aligns wake time to the minute. Sleep times defined in config.cpp.
  */
-void beginDeepSleep(unsigned long startTime, tm *timeInfo)
+void beginDeepSleep(unsigned long startTime, tm *timeInfo, bool fromError = false)
 {
   if (!getLocalTime(timeInfo))
   {
     Serial.println(TXT_REFERENCING_OLDER_TIME_NOTICE);
   }
 
+  int deepSleepDuration = SLEEP_DURATION;
+  if (fromError)
+  {
+    deepSleepDuration = ERROR_SLEEP_DURATION;
+  }
+
   // To simplify sleep time calculations, the current time stored by timeInfo
   // will be converted to time relative to the WAKE_TIME. This way if a
-  // SLEEP_DURATION is not a multiple of 60 minutes it can be more trivially,
+  // deepSleepDuration is not a multiple of 60 minutes it can be more trivially,
   // aligned and it can easily be deterimined whether we must sleep for
   // additional time due to bedtime.
   // i.e. when curHour == 0, then timeInfo->tm_hour == WAKE_TIME
@@ -71,17 +77,17 @@ void beginDeepSleep(unsigned long startTime, tm *timeInfo)
   const int curSecond = curHour * 3600
                       + timeInfo->tm_min * 60
                       + timeInfo->tm_sec;
-  const int desiredSleepSeconds = SLEEP_DURATION * 60;
-  const int offsetMinutes = curMinute % SLEEP_DURATION;
+  const int desiredSleepSeconds = deepSleepDuration * 60;
+  const int offsetMinutes = curMinute % deepSleepDuration;
   const int offsetSeconds = curSecond % desiredSleepSeconds;
 
-  // align wake time to nearest multiple of SLEEP_DURATION
-  int sleepMinutes = SLEEP_DURATION - offsetMinutes;
+  // align wake time to nearest multiple of deepSleepDuration
+  int sleepMinutes = deepSleepDuration - offsetMinutes;
   if (desiredSleepSeconds - offsetSeconds < 120
    || offsetSeconds / (float)desiredSleepSeconds > 0.95f)
-  { // if we have a sleep time less than 2 minutes OR less 5% SLEEP_DURATION,
+  { // if we have a sleep time less than 2 minutes OR less 5% deepSleepDuration,
     // skip to next alignment
-    sleepMinutes += SLEEP_DURATION;
+    sleepMinutes += deepSleepDuration;
   }
 
   // estimated wake time, if this falls in a sleep period then sleepDuration
@@ -223,7 +229,7 @@ void setup()
       } while (display.nextPage());
     }
     powerOffDisplay();
-    beginDeepSleep(startTime, &timeInfo);
+    beginDeepSleep(startTime, &timeInfo, true);
   }
 
   // TIME SYNCHRONIZATION
@@ -239,7 +245,7 @@ void setup()
       drawError(wi_time_4_196x196, TXT_TIME_SYNCHRONIZATION_FAILED);
     } while (display.nextPage());
     powerOffDisplay();
-    beginDeepSleep(startTime, &timeInfo);
+    beginDeepSleep(startTime, &timeInfo, true);
   }
 
   // MAKE API REQUESTS
@@ -255,6 +261,11 @@ void setup()
   int rxStatus = getOWMonecall(client, owm_onecall);
   if (rxStatus != HTTP_CODE_OK)
   {
+    // Perform one retry
+    rxStatus = getOWMonecall(client, owm_onecall);
+  }
+  if (rxStatus != HTTP_CODE_OK)
+  {
     killWiFi();
     statusStr = "One Call " + OWM_ONECALL_VERSION + " API";
     tmpStr = String(rxStatus, DEC) + ": " + getHttpResponsePhrase(rxStatus);
@@ -264,9 +275,14 @@ void setup()
       drawError(wi_cloud_down_196x196, statusStr, tmpStr);
     } while (display.nextPage());
     powerOffDisplay();
-    beginDeepSleep(startTime, &timeInfo);
+    beginDeepSleep(startTime, &timeInfo, true);
   }
   rxStatus = getOWMairpollution(client, owm_air_pollution);
+  if (rxStatus != HTTP_CODE_OK)
+  {
+    // Perform one retry
+    rxStatus = getOWMairpollution(client, owm_air_pollution);
+  }
   if (rxStatus != HTTP_CODE_OK)
   {
     killWiFi();
@@ -278,7 +294,7 @@ void setup()
       drawError(wi_cloud_down_196x196, statusStr, tmpStr);
     } while (display.nextPage());
     powerOffDisplay();
-    beginDeepSleep(startTime, &timeInfo);
+    beginDeepSleep(startTime, &timeInfo, true);
   }
   killWiFi(); // WiFi no longer needed
 


### PR DESCRIPTION
Add secondarily configurable Error_Sleep_Duration for faster recovery from failed data retrieval attempts rather than waiting for a standard-duration data refresh (while showing the error screen).  Add one retry for each API if the initial requests receive an unsuccessful response.