### PR TITLE
Updating README to include how to manually put ESP32-E in "download mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,9 @@ PlatformIO for VSCode is used for managing dependencies, code compilation, and u
 
       - You will only see this if you have the PlatformIO extension installed.
 
-      - If you are getting errors during the upload process, you may need to install drivers to allow you to upload code to the ESP32.
+      - If using a FireBeetle 2 ESP32-E and you receive the error `Wrong boot mode detected (0x13)! The chip needs to be in download mode.` unplug the power from the board, connect GPIO0 ([labeled 0/D5](https://wiki.dfrobot.com/FireBeetle_Board_ESP32_E_SKU_DFR0654#target_5)) to GND, and power it back up to put the board in download mode.
 
+      - If you are getting other errors during the upload process, you may need to install drivers to allow you to upload code to the ESP32.
 ### OpenWeatherMap API Key
 
 Sign up here to get an API key; it's free. <https://openweathermap.org/api>


### PR DESCRIPTION
This took me quite a while to track down yesterday when attempting to get this project running. It doesn't sound like most folks will run into this, but the lack of clear documentation on how to enter "download mode" on the dfrobot ESP32-E wiki makes it an adventure for those who do. Hopefully this will prevent anyone else from wasting half an evening trying different drivers, cables, IDEs, etc.