### PR TITLE
Add ability to use several WiFi networks

### DIFF
--- a/platformio/include/client_utils.h
+++ b/platformio/include/client_utils.h
@@ -27,7 +27,7 @@
   #include <WiFiClientSecure.h>
 #endif
 
-wl_status_t startWiFi(int &wifiRSSI);
+wl_status_t startWiFi(int &wifiRSSI, wifi_network_t wifi);
 void killWiFi();
 bool waitForSNTPSync(tm *timeInfo);
 bool printLocalTime(tm *timeInfo);

--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -279,8 +279,6 @@ extern const uint8_t PIN_BME_SDA;
 extern const uint8_t PIN_BME_SCL;
 extern const uint8_t PIN_BME_PWR;
 extern const uint8_t BME_ADDRESS;
-extern const char *WIFI_SSID;
-extern const char *WIFI_PASSWORD;
 extern const unsigned long WIFI_TIMEOUT;
 extern const unsigned HTTP_CLIENT_TCP_TIMEOUT;
 extern const String OWM_APIKEY;
@@ -309,6 +307,12 @@ extern const unsigned long LOW_BATTERY_SLEEP_INTERVAL;
 extern const unsigned long VERY_LOW_BATTERY_SLEEP_INTERVAL;
 extern const uint32_t MAX_BATTERY_VOLTAGE;
 extern const uint32_t MIN_BATTERY_VOLTAGE;
+extern uint8_t WIFI_NETWORKS_COUNT;
+struct wifi_network_t {
+    const char *ssid;
+    const char *password;
+};
+extern struct wifi_network_t wifi_networks[];
 
 // CONFIG VALIDATION - DO NOT MODIFY
 #if !(  defined(DISP_BW_V2)  \

--- a/platformio/src/client_utils.cpp
+++ b/platformio/src/client_utils.cpp
@@ -55,11 +55,11 @@
  *
  * Returns WiFi status.
  */
-wl_status_t startWiFi(int &wifiRSSI)
+wl_status_t startWiFi(int &wifiRSSI, wifi_network_t wifi)
 {
   WiFi.mode(WIFI_STA);
-  Serial.printf("%s '%s'", TXT_CONNECTING_TO, WIFI_SSID);
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  Serial.printf("%s '%s'", TXT_CONNECTING_TO, wifi.ssid);
+  WiFi.begin(wifi.ssid, wifi.password);
 
   // timeout if WiFi does not connect in WIFI_TIMEOUT ms from now
   unsigned long timeout = millis() + WIFI_TIMEOUT;
@@ -81,7 +81,7 @@ wl_status_t startWiFi(int &wifiRSSI)
   }
   else
   {
-    Serial.printf("%s '%s'\n", TXT_COULD_NOT_CONNECT_TO, WIFI_SSID);
+    Serial.printf("%s '%s'\n", TXT_COULD_NOT_CONNECT_TO, wifi.ssid);
   }
   return connection_status;
 } // startWiFi

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -44,8 +44,14 @@ const uint8_t PIN_BME_PWR =  4;   // Irrelevant if directly connected to 3.3V
 const uint8_t BME_ADDRESS = 0x76; // If sensor does not work, try 0x77
 
 // WIFI
-const char *WIFI_SSID     = "ssid";
-const char *WIFI_PASSWORD = "password";
+
+// List of Wi-Fi networks to try to connect to in the order of preference
+wifi_network_t wifi_networks[] = {
+    {"ssid", "password"},
+};
+
+uint8_t WIFI_NETWORKS_COUNT = sizeof(wifi_networks) / sizeof(wifi_networks[0]);
+
 const unsigned long WIFI_TIMEOUT = 10000; // ms, WiFi connection timeout.
 
 // HTTP

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -201,7 +201,14 @@ void setup()
 
   // START WIFI
   int wifiRSSI = 0; // “Received Signal Strength Indicator"
-  wl_status_t wifiStatus = startWiFi(wifiRSSI);
+  wl_status_t wifiStatus = WL_DISCONNECTED;
+  for(int i = 0; i < WIFI_NETWORKS_COUNT; i++) {
+    wifiStatus = startWiFi(wifiRSSI, wifi_networks[i]);
+    if (wifiStatus == WL_CONNECTED) {
+      break;
+    }
+  }
+
   if (wifiStatus != WL_CONNECTED)
   { // WiFi Connection Failed
     killWiFi();


### PR DESCRIPTION
This allows to specify any number of Wi-Fi networks to connect to when starting/waking up.
It will try them sequentially until one succeeds or all fail.