### PR TITLE
add support for BME680 sensor

### DIFF
--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -258,6 +258,11 @@
 // NON-VOLATILE STORAGE (NVS) NAMESPACE
 #define NVS_NAMESPACE "weather_epd"
 
+// BME sensor selection
+// Uncomment only one SENSOR_BME280 or SENSOR_BME680
+#define SENSOR_BME280
+// #define SENSOR_BME680
+
 // DEBUG
 //   If defined, enables increase verbosity over the serial port.
 //   level 0: basic status information, assists troubleshooting (default)

--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -42,6 +42,11 @@
 #define DRIVER_DESPI_C02
 // #define DRIVER_WAVESHARE
 
+// INDOOR ENVIRONMENT SENSOR
+// Uncomment the macro that identifies your sensor.
+#define SENSOR_BME280
+// #define SENSOR_BME680
+
 // 3 COLOR E-INK ACCENT COLOR
 // Defines the 3rd color to be used when a 3+ color display is selected.
 #if defined(DISP_3C_B) || defined(DISP_7C_F)
@@ -258,11 +263,6 @@
 // NON-VOLATILE STORAGE (NVS) NAMESPACE
 #define NVS_NAMESPACE "weather_epd"
 
-// BME sensor selection
-// Uncomment only one SENSOR_BME280 or SENSOR_BME680
-#define SENSOR_BME280
-// #define SENSOR_BME680
-
 // DEBUG
 //   If defined, enables increase verbosity over the serial port.
 //   level 0: basic status information, assists troubleshooting (default)
@@ -325,6 +325,10 @@ extern const uint32_t MIN_BATTERY_VOLTAGE;
 #if !(  defined(DRIVER_WAVESHARE) \
       ^ defined(DRIVER_DESPI_C02))
   #error Invalid configuration. Exactly one driver board must be selected.
+#endif
+#if !(  defined(SENSOR_BME280) \
+      ^ defined(SENSOR_BME680))
+  #error Invalid configuration. Exactly one sensor must be selected.
 #endif
 #if !(defined(LOCALE))
   #error Invalid configuration. Locale not selected.

--- a/platformio/platformio.ini
+++ b/platformio/platformio.ini
@@ -22,6 +22,7 @@ build_unflags = '-std=gnu++11'
 build_flags = '-Wall' '-std=gnu++17'
 lib_deps =
   adafruit/Adafruit BME280 Library @ 2.2.4
+  adafruit/Adafruit BME680 Library @ 2.0.5
   adafruit/Adafruit BusIO @ 1.17.0
   adafruit/Adafruit Unified Sensor @ 1.1.15
   bblanchon/ArduinoJson @ 7.3.1

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -41,7 +41,7 @@ const uint8_t PIN_EPD_PWR  = 26; // Irrelevant if directly connected to 3.3V
 const uint8_t PIN_BME_SDA = 17;
 const uint8_t PIN_BME_SCL = 16;
 const uint8_t PIN_BME_PWR =  4;   // Irrelevant if directly connected to 3.3V
-const uint8_t BME_ADDRESS = 0x77; // If SDO is grounded (often on 4pin platins) use 0x76 instead
+const uint8_t BME_ADDRESS = 0x76; // 0x76 if SDO -> GND; 0x77 if SDO -> VCC
 
 // WIFI
 const char *WIFI_SSID     = "ssid";

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -41,7 +41,7 @@ const uint8_t PIN_EPD_PWR  = 26; // Irrelevant if directly connected to 3.3V
 const uint8_t PIN_BME_SDA = 17;
 const uint8_t PIN_BME_SCL = 16;
 const uint8_t PIN_BME_PWR =  4;   // Irrelevant if directly connected to 3.3V
-const uint8_t BME_ADDRESS = 0x76; // If sensor does not work, try 0x77
+const uint8_t BME_ADDRESS = 0x77; // If SDO is grounded (often on 4pin platins) use 0x76 instead
 
 // WIFI
 const char *WIFI_SSID     = "ssid";

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -15,8 +15,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include <Arduino.h>
+#if defined(SENSOR_BME280)
 #include <Adafruit_BME280.h>
+#endif
+#if defined(SENSOR_BME680)
+#include <Adafruit_BME680.h>
+#endif
 #include <Adafruit_Sensor.h>
 #include <Preferences.h>
 #include <time.h>
@@ -26,7 +32,6 @@
 #include "_locale.h"
 #include "api_response.h"
 #include "client_utils.h"
-#include "config.h"
 #include "display_utils.h"
 #include "icons/icons_196x196.h"
 #include "renderer.h"
@@ -282,18 +287,27 @@ void setup()
   }
   killWiFi(); // WiFi no longer needed
 
-  // GET INDOOR TEMPERATURE AND HUMIDITY, start BME280...
+  // GET INDOOR TEMPERATURE AND HUMIDITY, start BMEx80...
   pinMode(PIN_BME_PWR, OUTPUT);
   digitalWrite(PIN_BME_PWR, HIGH);
+  TwoWire I2C_bme = TwoWire(0);
+  I2C_bme.begin(PIN_BME_SDA, PIN_BME_SCL, 100000); // 100kHz
   float inTemp     = NAN;
   float inHumidity = NAN;
+#if defined(SENSOR_BME280)  
   Serial.print(String(TXT_READING_FROM) + " BME280... ");
-  TwoWire I2C_bme = TwoWire(0);
   Adafruit_BME280 bme;
 
-  I2C_bme.begin(PIN_BME_SDA, PIN_BME_SCL, 100000); // 100kHz
   if(bme.begin(BME_ADDRESS, &I2C_bme))
   {
+#endif    
+#if defined(SENSOR_BME680)
+  Serial.print(String(TXT_READING_FROM) + " BME680... ");
+  Adafruit_BME680 bme(&I2C_bme);
+
+  if(bme.begin(BME_ADDRESS))
+  {
+#endif  
     inTemp     = bme.readTemperature(); // Celsius
     inHumidity = bme.readHumidity();    // %
 

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -18,10 +18,10 @@
 #include "config.h"
 #include <Arduino.h>
 #if defined(SENSOR_BME280)
-#include <Adafruit_BME280.h>
+  #include <Adafruit_BME280.h>
 #endif
 #if defined(SENSOR_BME680)
-#include <Adafruit_BME680.h>
+  #include <Adafruit_BME680.h>
 #endif
 #include <Adafruit_Sensor.h>
 #include <Preferences.h>
@@ -294,20 +294,20 @@ void setup()
   I2C_bme.begin(PIN_BME_SDA, PIN_BME_SCL, 100000); // 100kHz
   float inTemp     = NAN;
   float inHumidity = NAN;
-#if defined(SENSOR_BME280)  
+#if defined(SENSOR_BME280)
   Serial.print(String(TXT_READING_FROM) + " BME280... ");
   Adafruit_BME280 bme;
 
   if(bme.begin(BME_ADDRESS, &I2C_bme))
   {
-#endif    
+#endif
 #if defined(SENSOR_BME680)
   Serial.print(String(TXT_READING_FROM) + " BME680... ");
   Adafruit_BME680 bme(&I2C_bme);
 
   if(bme.begin(BME_ADDRESS))
   {
-#endif  
+#endif
     inTemp     = bme.readTemperature(); // Celsius
     inHumidity = bme.readHumidity();    // %
 


### PR DESCRIPTION
Add the option to use a BME680 sensor or the BME280. Both are pin compatible but the library is not the same. 

The sensor is more accurate, needs less power and has a gas-sensor in addition. 