### PR TITLE
feat: implement OTA via ElegantOTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ PlatformIO for VSCode is used for managing dependencies, code compilation, and u
 
       - If you are getting other errors during the upload process, you may need to install drivers to allow you to upload code to the ESP32.
 
+   c. **After** the initial upload via USB you can make use of the OTA (over the air) implementation in this project.
+
+      - Click the check mark (✔) along the bottom of the VSCode window to build the firmware using the PlatformIO plugin. (Should say "PlatformIO: Build" if you hover over it.)
+
+      - Restart/Reset the ESP32 board using the reset button while holding down the `User Button` (IO27/D4 for the FireBeetle 2 ESP32-E). The button can be configured via the variable `BTN_ENABLE_OTA_SERVER` in `config.ccp`.
+
+      - This will run a OTA server on the ESP over which the firmware can be updated without a wired connection. Per default the server will run for 90 seconds. The value can be adjusted via the `OTA_SERVER_TIMEOUT_SECONDS` variable in `config.cpp`. After this given time the ESP will reboot into the normal operation mode without OTA capabilities.
+
+      - Hold the `User Button` until the onboard LED (besides the USB-C connector) lights up.
+
+      - Open a webbrowser and enter your ESP32 IP address and hit enter. (You sould be redirected to `http://<ip-address>/upload`.)
+
+      - Upload the built firmware located at `/<esp32-weather-epd-directory>/platformio/.pio/build/dfrobot_firebeetle2_esp32e/firmware.bin` through the webui.
+
+      - The ESP board will reboot into normal operation mode.
+
 ### OpenWeatherMap API Key
 
 Sign up here to get an API key; it's free. <https://openweathermap.org/api>

--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -361,6 +361,8 @@ extern const unsigned long LOW_BATTERY_SLEEP_INTERVAL;
 extern const unsigned long VERY_LOW_BATTERY_SLEEP_INTERVAL;
 extern const uint32_t MAX_BATTERY_VOLTAGE;
 extern const uint32_t MIN_BATTERY_VOLTAGE;
+extern const uint8_t BTN_ENABLE_OTA_SERVER;
+extern const uint16_t OTA_SERVER_TIMEOUT_SECONDS;
 
 // CONFIG VALIDATION - DO NOT MODIFY
 #if !(  defined(DISP_BW_V2)  \

--- a/platformio/ota_nofs_4MB.csv
+++ b/platformio/ota_nofs_4MB.csv
@@ -1,0 +1,6 @@
+#   Name, Type,  SubType,   Offset,      Size, Flags
+     nvs, data,      nvs,   0x9000,    0x5000,
+ otadata, data,      ota,   0xE000,    0x2000,
+    app0,  app,    ota_0,  0x10000,  0x1F0000,
+    app1,  app,    ota_1, 0x200000,  0x1F0000,
+coredump, data, coredump, 0x3F0000,   0x10000,

--- a/platformio/platformio.ini
+++ b/platformio/platformio.ini
@@ -20,6 +20,7 @@ platform = espressif32 @ 6.13.0
 framework = arduino
 build_unflags = '-std=gnu++11'
 build_flags = '-Wall' '-std=gnu++17'
+lib_compat_mode = strict
 lib_deps =
   adafruit/Adafruit BME280 Library @ 2.3.0
   adafruit/Adafruit BME680 Library @ 2.0.6
@@ -27,6 +28,7 @@ lib_deps =
   adafruit/Adafruit Unified Sensor @ 1.1.15
   bblanchon/ArduinoJson @ 7.4.3
   zinggjm/GxEPD2 @ 1.6.8
+  ayushsharma82/ElegantOTA @ 3.1.7
 
 
 [env:dfrobot_firebeetle2_esp32e]
@@ -34,7 +36,7 @@ board = dfrobot_firebeetle2_esp32e
 monitor_speed = 115200
 ; override default partition table
 ; https://github.com/espressif/arduino-esp32/tree/master/tools/partitions
-board_build.partitions = huge_app.csv
+board_build.partitions = ota_nofs_4MB.csv
 ; change MCU frequency, 240MHz -> 80MHz (for better power efficiency)
 board_build.f_cpu = 80000000L
 

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -155,6 +155,14 @@ const unsigned long VERY_LOW_BATTERY_SLEEP_INTERVAL = 120; // (minutes)
 const uint32_t MAX_BATTERY_VOLTAGE = 4200; // (millivolts)
 const uint32_t MIN_BATTERY_VOLTAGE = 3000; // (millivolts)
 
+// Variables for OTA server
+// To enable the OTA server one has to hold a button defined here while starting
+// or restting the ESP32 board. If the board is not manually reset the board
+// will automatically reset itself into normal operation mode after the given
+// time.
+const uint8_t BTN_ENABLE_OTA_SERVER = 27;
+const uint16_t OTA_SERVER_TIMEOUT_SECONDS = 90;
+
 // See config.h for the below options
 // E-PAPER PANEL
 // LOCALE


### PR DESCRIPTION
I have added OTA functionality to this project that allows to update the firmware wirelessly (over wifi).

I think the Readme section describes it quiet well:

**After** the initial upload via USB you can make use of the OTA (over the air) implementation in this project.
  - Click the check mark (✔) along the bottom of the VSCode window to build the firmware using the PlatformIO plugin. (Should say "PlatformIO: Build" if you hover over it.)
  - Restart/Reset the ESP32 board using the reset button while holding down the `User Button` (IO27/D4 for the FireBeetle 2 ESP32-E). The button can be configured via the variable `BTN_ENABLE_OTA_SERVER` in `config.ccp`.
  - This will run a OTA server on the ESP over which the firmware can be updated without a wired connection. Per default the server will run for 90 seconds. The value can be adjusted via the `OTA_SERVER_TIMEOUT_SECONDS` variable in `config.cpp`. After this given time the ESP will reboot into the normal operation mode without OTA capabilities.
  - Hold the `User Button` until the onboard LED (besides the USB-C connector) lights up.
  - Open a webbrowser and enter your ESP32 IP address and hit enter. (You sould be redirected to `http://<ip-address>/upload`.)
  - Upload the built firmware located at `/<esp32-weather-epd-directory>/platformio/.pio/build/dfrobot_firebeetle2_esp32e/firmware.bin` through the webui.
  - The ESP board will reboot into normal operation mode.