### PR TITLE
Next hour rain forecast

### DIFF
--- a/platformio/include/_locale.h
+++ b/platformio/include/_locale.h
@@ -111,6 +111,12 @@ extern const char *TXT_UNITS_PRECIP_MILLIMETERS;
 extern const char *TXT_UNITS_PRECIP_CENTIMETERS;
 extern const char *TXT_UNITS_PRECIP_INCHES;
 
+// NEXT HOUR RAIN FORECAST
+extern const char *TXT_RAIN_CONTINUOUS;
+extern const char *TXT_RAIN_UNTIL;
+extern const char *TXT_RAIN_FROM;
+extern const char *TXT_RAIN_FROM_TO;
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 extern const char *TXT_LOW_BATTERY;

--- a/platformio/include/api_response.h
+++ b/platformio/include/api_response.h
@@ -25,7 +25,7 @@
 #include <HTTPClient.h>
 #include <WiFi.h>
 
-#define OWM_NUM_MINUTELY       1 // 61
+#define OWM_NUM_MINUTELY      60 // 60
 #define OWM_NUM_HOURLY        48 // 48
 #define OWM_NUM_DAILY          8 // 8
 #define OWM_NUM_ALERTS         8 // OpenWeatherMaps does not specify a limit, but if you need more alerts you are probably doomed.
@@ -93,7 +93,7 @@ typedef struct owm_current
 typedef struct owm_minutely
 {
   int64_t dt;               // Time of the forecasted data, unix, UTC
-  float   precipitation;    // Precipitation volume, mm
+  float   precipitation;    // Precipitation volume, mm/h
 } owm_minutely_t;
 
 /*
@@ -172,8 +172,7 @@ typedef struct owm_resp_onecall
   String  timezone;         // Timezone name for the requested location
   int     timezone_offset;  // Shift in seconds from UTC
   owm_current_t   current;
-  // owm_minutely_t  minutely[OWM_NUM_MINUTELY];
-
+  owm_minutely_t  minutely[OWM_NUM_MINUTELY];
   owm_hourly_t    hourly[OWM_NUM_HOURLY];
   owm_daily_t     daily[OWM_NUM_DAILY];
   std::vector<owm_alerts_t> alerts;

--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -295,6 +295,16 @@
 //   Disable alerts by changing the DISPLAY_ALERTS macro to 0.
 #define DISPLAY_ALERTS 1
 
+//   When there are no alerts to display (either DISPLAY_ALERTS is set to 0 or
+//   there are no current alerts), the precipirations for the next hour can be
+//   displayed in the alerts area.
+//   Disable by changing the DISPLAY_NEXT_HOUR_PRECIP macro to 0.
+#define DISPLAY_NEXT_HOUR_PRECIP 1
+// Threshold to consider precipitation as "rain" for a period (mm/h)
+#define PRECIP_THRESHOLD_PERIOD 0.1f
+// Maximum gap in minutes to group precipitations as a single period
+#define PRECIP_MAX_GAP_MINUTES 5
+
 // STATUS BAR EXTRAS
 //   Extra information that can be displayed on the status bar. Set to 1 to
 //   enable.

--- a/platformio/include/locales/locale_de_DE.inc
+++ b/platformio/include/locales/locale_de_DE.inc
@@ -147,6 +147,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Low Battery";

--- a/platformio/include/locales/locale_en_GB.inc
+++ b/platformio/include/locales/locale_en_GB.inc
@@ -139,6 +139,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Low Battery";

--- a/platformio/include/locales/locale_en_US.inc
+++ b/platformio/include/locales/locale_en_US.inc
@@ -139,6 +139,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Low Battery";

--- a/platformio/include/locales/locale_et_EE.inc
+++ b/platformio/include/locales/locale_et_EE.inc
@@ -146,6 +146,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Aku t\xFChi";

--- a/platformio/include/locales/locale_fi_FI.inc
+++ b/platformio/include/locales/locale_fi_FI.inc
@@ -147,6 +147,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Low Battery";

--- a/platformio/include/locales/locale_fr_FR.inc
+++ b/platformio/include/locales/locale_fr_FR.inc
@@ -147,6 +147,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Pluie sans interruption";
+const char *TXT_RAIN_UNTIL      = "Pluie jusqu'\340 %s";
+const char *TXT_RAIN_FROM       = "Pluie \340 partir de %s";
+const char *TXT_RAIN_FROM_TO    = "Pluie de %s \340 %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Batterie Faible";

--- a/platformio/include/locales/locale_it_IT.inc
+++ b/platformio/include/locales/locale_it_IT.inc
@@ -147,6 +147,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Batteria quasi scarica";

--- a/platformio/include/locales/locale_nl_BE.inc
+++ b/platformio/include/locales/locale_nl_BE.inc
@@ -146,6 +146,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Low Battery";

--- a/platformio/include/locales/locale_pt_BR.inc
+++ b/platformio/include/locales/locale_pt_BR.inc
@@ -147,6 +147,12 @@ const char *TXT_UNITS_PRECIP_MILLIMETERS = "mm";
 const char *TXT_UNITS_PRECIP_CENTIMETERS = "cm";
 const char *TXT_UNITS_PRECIP_INCHES      = "in";
 
+// NEXT HOUR RAIN FORECAST
+const char *TXT_RAIN_CONTINUOUS = "Continuous rain";
+const char *TXT_RAIN_UNTIL      = "Rain until %s";
+const char *TXT_RAIN_FROM       = "Rain from %s";
+const char *TXT_RAIN_FROM_TO    = "Rain from %s to %s";
+
 // MISCELLANEOUS MESSAGES
 // Title Case
 const char *TXT_LOW_BATTERY = "Bateria Baixa";

--- a/platformio/include/renderer.h
+++ b/platformio/include/renderer.h
@@ -77,6 +77,8 @@ void drawCurrentConditions(const owm_current_t &current,
 void drawForecast(const owm_daily_t *daily, tm timeInfo);
 void drawAlerts(std::vector<owm_alerts_t> &alerts,
                 const String &city, const String &date);
+void drawNextHourPrecip(const owm_minutely_t *minutely,
+                        const String &city, const String &date);
 void drawLocationDate(const String &city, const String &date);
 void drawOutlookGraph(const owm_hourly_t *hourly, const owm_daily_t *daily,
                       tm timeInfo);

--- a/platformio/src/api_response.cpp
+++ b/platformio/src/api_response.cpp
@@ -27,7 +27,7 @@ DeserializationError deserializeOneCall(WiFiClient &json,
 
   JsonDocument filter;
   filter["current"]  = true;
-  filter["minutely"] = false;
+  filter["minutely"] = DISPLAY_NEXT_HOUR_PRECIP;
   filter["hourly"]   = true;
   filter["daily"]    = true;
 #if !DISPLAY_ALERTS
@@ -89,19 +89,20 @@ DeserializationError deserializeOneCall(WiFiClient &json,
   r.current.weather.description = current_weather["description"].as<const char *>();
   r.current.weather.icon        = current_weather["icon"]       .as<const char *>();
 
-  // minutely forecast is currently unused
-  // i = 0;
-  // for (JsonObject minutely : doc["minutely"].as<JsonArray>())
-  // {
-  //   r.minutely[i].dt            = minutely["dt"]           .as<int64_t>();
-  //   r.minutely[i].precipitation = minutely["precipitation"].as<float>();
+#if DISPLAY_NEXT_HOUR_PRECIP
+  i = 0;
+  for (JsonObject minutely : doc["minutely"].as<JsonArray>())
+  {
+    r.minutely[i].dt            = minutely["dt"]           .as<int64_t>();
+    r.minutely[i].precipitation = minutely["precipitation"].as<float>();
 
-  //   if (i == OWM_NUM_MINUTELY - 1)
-  //   {
-  //     break;
-  //   }
-  //   ++i;
-  // }
+    if (i == OWM_NUM_MINUTELY - 1)
+    {
+      break;
+    }
+    ++i;
+  }
+#endif
 
   i = 0;
   for (JsonObject hourly : doc["hourly"].as<JsonArray>())

--- a/platformio/src/client_utils.cpp
+++ b/platformio/src/client_utils.cpp
@@ -154,10 +154,13 @@ bool waitForSNTPSync(tm *timeInfo)
   DeserializationError jsonErr = {};
   String uri = "/data/" + OWM_ONECALL_VERSION
                + "/onecall?lat=" + LAT + "&lon=" + LON + "&lang=" + OWM_LANG
-               + "&units=standard&exclude=minutely";
-#if !DISPLAY_ALERTS
-  // exclude alerts
-  uri += ",alerts";
+               + "&units=standard";
+#if !DISPLAY_NEXT_HOUR_PRECIP && !DISPLAY_ALERTS
+  uri += "&exclude=minutely,alerts";
+#elif !DISPLAY_NEXT_HOUR_PRECIP
+  uri += "&exclude=minutely";
+#elif !DISPLAY_ALERTS
+  uri += "&exclude=alerts";
 #endif
 
   // This string is printed to terminal to help with debugging. The API key is

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -354,6 +354,13 @@ void setup()
 #if DISPLAY_ALERTS
     drawAlerts(owm_onecall.alerts, CITY_STRING, dateStr);
 #endif
+#if DISPLAY_NEXT_HOUR_PRECIP
+    // Display next hour precipitations at the alerts location if none
+    if (owm_onecall.alerts.size() == 0)
+    {
+      drawNextHourPrecip(owm_onecall.minutely, CITY_STRING, dateStr);
+    }
+#endif
     drawStatusBar(statusStr, refreshTimeStr, wifiRSSI, batteryVoltage);
   } while (display.nextPage());
   powerOffDisplay();


### PR DESCRIPTION
When there are no alerts, the empty space can be used to display rain forecast for the next hour based on the "minutely" forecast.

I added two config options to avoid showing an alert when just a few drops forecasted, and to group interrupted rain periods.