### PR TITLE
BME sensor delay

### DIFF
--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -47,6 +47,10 @@
 #define SENSOR_BME280
 // #define SENSOR_BME680
 
+// If you enconter issues with the BME280 sensor showing no data, uncomment and
+// add a small delay before reading it's value. 300ms seems to work for most people
+// #define SENSOR_INIT_DELAY_MS 300
+
 // 3 COLOR E-INK ACCENT COLOR
 // Defines the 3rd color to be used when a 3+ color display is selected.
 #if defined(DISP_3C_B) || defined(DISP_7C_F)

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -292,6 +292,9 @@ void setup()
   // GET INDOOR TEMPERATURE AND HUMIDITY, start BMEx80...
   pinMode(PIN_BME_PWR, OUTPUT);
   digitalWrite(PIN_BME_PWR, HIGH);
+#if defined(SENSOR_INIT_DELAY_MS) && SENSOR_INIT_DELAY_MS > 0
+  delay(SENSOR_INIT_DELAY_MS);
+#endif
   TwoWire I2C_bme = TwoWire(0);
   I2C_bme.begin(PIN_BME_SDA, PIN_BME_SCL, 100000); // 100kHz
   float inTemp     = NAN;


### PR DESCRIPTION
Like other people, i ran through the issue of the BME sensors not being ready when trying to read the temperature : 

https://github.com/lmarzen/esp32-weather-epd/issues/191
https://github.com/lmarzen/esp32-weather-epd/issues/181

Adding an optional config option to add a delay to let the sensor be initialized.