### PR TITLE
Add support for the Seeed reTerminal E1001 and E1002

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Here are two (slightly outdated) examples utilizing various configuration option
   | Battery         | 3.7V LiPo w/ JST-PH2.0 connector             | Any capacity (e.g., 5000mAh for 6+ months runtime)        | Available from multiple vendors.                                             |
   | Enclosure       | See [Enclosure Options](#enclosure-options). | See [Enclosure Options](#enclosure-options).              | See [Enclosure Options](#enclosure-options).                                 |
 
+  Alternatively, the Seeed Studio **reTerminal E1001** (7.5" black/white) and
+  **reTerminal E1002** (7.3" Spectra 6 full color) are supported as
+  all-in-one devices: they combine an ESP32-S3, the e-paper panel, an
+  onboard SHT4x temperature/humidity sensor, a battery, and an enclosure --
+  no wiring needed. Build with `pio run -e seeed_reterminal_e1001` or
+  `-e seeed_reterminal_e1002`; the panel, sensor, and pin mapping are
+  selected automatically.
+
 Other items needed:
 - Wires ("Jumper Wires" if looking to minimize/avoid soldering).
 - Solder Iron + Solder (unless following [Solder-Free Component Selection](#solder-free-component-selection-optional)).

--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -29,11 +29,21 @@
 //   DISP_7C_E6 - 7.3in spectra 6 e-Paper (E6) 800x480px  7-Color
 //   DISP_BW_V1 - 7.5in e-Paper (v1)           640x384px  Black/White
 // Uncomment the macro that identifies your physical panel.
+// (Building with -e seeed_reterminal_e1002 or -e seeed_reterminal_e1001
+//  selects the panel automatically: the E1002's built-in 7.3in Spectra 6
+//  panel is a GDEP073E01 (DISP_7C_E6); the E1001's 7.5in monochrome panel
+//  is a GDEY075T7 (DISP_BW_V2).)
+#if defined(BOARD_RETERMINAL_E1001)
+  #define DISP_BW_V2
+#elif defined(BOARD_RETERMINAL_E1002)
+  #define DISP_7C_E6
+#else
 #define DISP_BW_V2
 // #define DISP_3C_B
 // #define DISP_7C_F
 // #define DISP_7C_E6
 // #define DISP_BW_V1
+#endif
 
 // E-PAPER DRIVER BOARD
 // The DESPI-C02 is the only officially supported driver board.
@@ -46,8 +56,14 @@
 
 // INDOOR ENVIRONMENT SENSOR
 // Uncomment the macro that identifies your sensor.
+// (The reTerminal E1001/E1002 have an SHT4x temperature/humidity sensor
+//  onboard, selected automatically when building their environments.)
+#ifdef BOARD_RETERMINAL_E1002
+  #define SENSOR_SHT4X
+#else
 #define SENSOR_BME280
 // #define SENSOR_BME680
+#endif
 
 // If you encounter issues with the BME280 sensor showing no data, uncomment and
 // add a small delay before reading it's value. 300ms seems to work for most people
@@ -333,6 +349,12 @@ extern const uint8_t PIN_BME_SDA;
 extern const uint8_t PIN_BME_SCL;
 extern const uint8_t PIN_BME_PWR;
 extern const uint8_t BME_ADDRESS;
+// Sentinel for pins a board does not have or need (e.g. hardwired supplies
+// on the reTerminal E-series).
+#define PIN_UNUSED 0xFF
+// Battery-divider enable pin (reTerminal E-series); PIN_UNUSED on boards
+// whose divider is always connected.
+extern const uint8_t PIN_BAT_EN;
 extern const char *WIFI_SSID;
 extern const char *WIFI_PASSWORD;
 extern const unsigned long WIFI_TIMEOUT;
@@ -377,7 +399,8 @@ extern const uint32_t MIN_BATTERY_VOLTAGE;
   #error Invalid configuration. Exactly one driver board must be selected.
 #endif
 #if !(  defined(SENSOR_BME280) \
-      ^ defined(SENSOR_BME680))
+      ^ defined(SENSOR_BME680) \
+      ^ defined(SENSOR_SHT4X))
   #error Invalid configuration. Exactly one sensor must be selected.
 #endif
 #if !(defined(LOCALE))

--- a/platformio/include/config.h
+++ b/platformio/include/config.h
@@ -345,6 +345,10 @@ extern const uint8_t PIN_EPD_SCK;
 extern const uint8_t PIN_EPD_MISO;
 extern const uint8_t PIN_EPD_MOSI;
 extern const uint8_t PIN_EPD_PWR;
+// microSD slot control pins, PIN_UNUSED on boards whose SD slot (if any)
+// does not share the ePaper SPI bus. See idleSDCard().
+extern const uint8_t PIN_SD_EN;
+extern const uint8_t PIN_SD_CS;
 extern const uint8_t PIN_BME_SDA;
 extern const uint8_t PIN_BME_SCL;
 extern const uint8_t PIN_BME_PWR;

--- a/platformio/include/display_utils.h
+++ b/platformio/include/display_utils.h
@@ -78,6 +78,7 @@ const char *getHttpResponsePhrase(int code);
 const char *getWifiStatusPhrase(wl_status_t status);
 void printHeapUsage();
 void disableBuiltinLED();
+void idleSDCard();
 const uint8_t *getMoonPhaseBitmap48(const owm_daily_t &daily);
 const char *getMoonPhaseStr(const owm_daily_t &daily);
 

--- a/platformio/include/renderer.h
+++ b/platformio/include/renderer.h
@@ -56,8 +56,22 @@
   #define DISP_WIDTH  800
   #define DISP_HEIGHT 480
   #include <GxEPD2_7C.h>
-  extern GxEPD2_7C<GxEPD2_730c_GDEP073E01,
-            GxEPD2_730c_GDEP073E01::HEIGHT / 4> display;
+  // Some GDEP073E01 panel variants (the reTerminal E1002's, for one) take
+  // longer than the stock driver's 20s busy timeout to complete a full
+  // refresh, which aborts the wait mid-update ("Busy Timeout!"). Raise the
+  // limit; it only matters when exceeded, so faster panels are unaffected.
+  class GxEPD2_730c_GDEP073E01_Patient : public GxEPD2_730c_GDEP073E01
+  {
+  public:
+    GxEPD2_730c_GDEP073E01_Patient(int16_t cs, int16_t dc, int16_t rst,
+                                   int16_t busy)
+        : GxEPD2_730c_GDEP073E01(cs, dc, rst, busy)
+    {
+      _busy_timeout = 45000000; // us
+    }
+  };
+  extern GxEPD2_7C<GxEPD2_730c_GDEP073E01_Patient,
+            GxEPD2_730c_GDEP073E01_Patient::HEIGHT / 4> display;
 #endif
 
 typedef enum alignment

--- a/platformio/platformio.ini
+++ b/platformio/platformio.ini
@@ -27,6 +27,7 @@ lib_deps =
   adafruit/Adafruit Unified Sensor @ 1.1.15
   bblanchon/ArduinoJson @ 7.4.3
   zinggjm/GxEPD2 @ 1.6.8
+  adafruit/Adafruit SHT4x Library @ 1.0.5
 
 
 [env:dfrobot_firebeetle2_esp32e]
@@ -38,6 +39,33 @@ board_build.partitions = huge_app.csv
 ; change MCU frequency, 240MHz -> 80MHz (for better power efficiency)
 board_build.f_cpu = 80000000L
 
+
+; Seeed reTerminal E1002 -- ESP32-S3 (XIAO ESP32S3 module) driving a built-in
+; 7.3in Spectra 6 panel (GDEP073E01, i.e. DISP_7C_E6). The
+; BOARD_RETERMINAL_E1002 flag selects the panel, the onboard SHT4x sensor,
+; and the pin mapping automatically (see config.h / config.cpp), so no file
+; edits are needed to build for this device:  pio run -e seeed_reterminal_e1002
+; ARDUINO_USB_CDC_ON_BOOT=0 routes Serial to UART0 (GPIO43/44), which the
+; E1002 wires to its CH340 USB-serial bridge -- the XIAO board definition
+; would otherwise send Serial to native USB-CDC where nothing listens.
+[env:seeed_reterminal_e1002]
+board = seeed_xiao_esp32s3
+monitor_speed = 115200
+board_build.partitions = huge_app.csv
+; change MCU frequency, 240MHz -> 80MHz (for better power efficiency)
+board_build.f_cpu = 80000000L
+build_flags = ${env.build_flags} '-D BOARD_RETERMINAL_E1002' '-D ARDUINO_USB_CDC_ON_BOOT=0'
+
+; Seeed reTerminal E1001 -- the same E-series mainboard as the E1002 (the env
+; keeps that board flag for every shared pin/sensor/button quirk); the extra
+; E1001 flag swaps the panel selection to its 7.5in monochrome panel (a
+; GDEY075T7, i.e. DISP_BW_V2):  pio run -e seeed_reterminal_e1001
+[env:seeed_reterminal_e1001]
+board = seeed_xiao_esp32s3
+monitor_speed = 115200
+board_build.partitions = huge_app.csv
+board_build.f_cpu = 80000000L
+build_flags = ${env.build_flags} '-D BOARD_RETERMINAL_E1002' '-D BOARD_RETERMINAL_E1001' '-D ARDUINO_USB_CDC_ON_BOOT=0'
 
 [env:firebeetle32]
 board = firebeetle32

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -26,8 +26,31 @@
 //       board's pinout to ensure you avoid using a pin with this shared 
 //       functionality.
 //
+#ifdef BOARD_RETERMINAL_E1002
+// Seeed reTerminal E1001/E1002 -- fixed internal wiring, do not change.
+// (Sources: Seeed wiki "Arduino Cookbook" pages for the reTerminal E Series.)
+// ADC pin used to measure battery voltage (GPIO1 = ADC1_CH0, 1:2 divider).
+const uint8_t PIN_BAT_ADC  = 1;
+// Must be driven HIGH to connect the battery divider to the ADC.
+const uint8_t PIN_BAT_EN   = 21;
+// Built-in panel (E1002: 7.3in Spectra 6 GDEP073E01; E1001: 7.5in GDEY075T7)
+const uint8_t PIN_EPD_BUSY = 13;
+const uint8_t PIN_EPD_CS   = 10;
+const uint8_t PIN_EPD_RST  = 12;
+const uint8_t PIN_EPD_DC   = 11;
+const uint8_t PIN_EPD_SCK  = 7;  // SPI bus shared with the microSD slot
+const uint8_t PIN_EPD_MISO = 8;  // (SD's MISO; the panel itself returns no data)
+const uint8_t PIN_EPD_MOSI = 9;
+const uint8_t PIN_EPD_PWR  = PIN_UNUSED; // panel supply is hardwired
+// Onboard SHT4x temperature/humidity sensor
+const uint8_t PIN_BME_SDA = 19;
+const uint8_t PIN_BME_SCL = 20;
+const uint8_t PIN_BME_PWR = PIN_UNUSED;  // sensor supply is hardwired
+const uint8_t BME_ADDRESS = 0x44;        // SHT4x fixed I2C address
+#else
 // ADC pin used to measure battery voltage
 const uint8_t PIN_BAT_ADC  = A2; // A0 for micro-usb firebeetle
+const uint8_t PIN_BAT_EN   = PIN_UNUSED; // FireBeetle divider is always connected
 // Pins for E-Paper Driver Board
 const uint8_t PIN_EPD_BUSY = 14; // 5 for micro-usb firebeetle
 const uint8_t PIN_EPD_CS   = 13;
@@ -42,6 +65,7 @@ const uint8_t PIN_BME_SDA = 17;
 const uint8_t PIN_BME_SCL = 16;
 const uint8_t PIN_BME_PWR =  4;   // Irrelevant if directly connected to 3.3V
 const uint8_t BME_ADDRESS = 0x76; // 0x76 if SDO -> GND; 0x77 if SDO -> VCC
+#endif // BOARD_RETERMINAL_E1002
 
 // WIFI
 const char *WIFI_SSID     = "ssid";

--- a/platformio/src/config.cpp
+++ b/platformio/src/config.cpp
@@ -42,6 +42,11 @@ const uint8_t PIN_EPD_SCK  = 7;  // SPI bus shared with the microSD slot
 const uint8_t PIN_EPD_MISO = 8;  // (SD's MISO; the panel itself returns no data)
 const uint8_t PIN_EPD_MOSI = 9;
 const uint8_t PIN_EPD_PWR  = PIN_UNUSED; // panel supply is hardwired
+// microSD slot. Unused by this firmware, but it sits on the panel's SPI bus
+// and must be parked -- see idleSDCard() in display_utils.cpp.
+// (The E1003 puts SD power enable on GPIO39 instead of 16.)
+const uint8_t PIN_SD_EN    = 16; // active high, powers the slot
+const uint8_t PIN_SD_CS    = 14;
 // Onboard SHT4x temperature/humidity sensor
 const uint8_t PIN_BME_SDA = 19;
 const uint8_t PIN_BME_SCL = 20;
@@ -60,6 +65,9 @@ const uint8_t PIN_EPD_SCK  = 18;
 const uint8_t PIN_EPD_MISO = 19; // 19 Master-In Slave-Out not used, as no data from display
 const uint8_t PIN_EPD_MOSI = 23;
 const uint8_t PIN_EPD_PWR  = 26; // Irrelevant if directly connected to 3.3V
+// No microSD slot sharing the panel's SPI bus on this wiring.
+const uint8_t PIN_SD_EN    = PIN_UNUSED;
+const uint8_t PIN_SD_CS    = PIN_UNUSED;
 // I2C Pins used for BME280
 const uint8_t PIN_BME_SDA = 17;
 const uint8_t PIN_BME_SCL = 16;

--- a/platformio/src/display_utils.cpp
+++ b/platformio/src/display_utils.cpp
@@ -40,9 +40,29 @@ uint32_t readBatteryVoltage()
   // __attribute__((unused)) disables compiler warnings about this variable
   // being unused (Clang, GCC) which is the case when DEBUG_LEVEL == 0.
   esp_adc_cal_value_t val_type __attribute__((unused));
+  if (PIN_BAT_EN != PIN_UNUSED)
+  { // some boards (reTerminal E-series) gate the divider behind an enable pin
+    pinMode(PIN_BAT_EN, OUTPUT);
+    digitalWrite(PIN_BAT_EN, HIGH);
+    delay(20); // let the divider settle
+  }
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+  // The legacy esp_adc_cal path below reads 0 on the ESP32-S3 (verified on
+  // the reTerminal E1002); Arduino's calibrated helper reads correctly there.
+  uint32_t s3MilliVolts = analogReadMilliVolts(PIN_BAT_ADC);
+#else
   adc_power_acquire();
   uint16_t adc_val = analogRead(PIN_BAT_ADC);
   adc_power_release();
+#endif
+  if (PIN_BAT_EN != PIN_UNUSED)
+  {
+    digitalWrite(PIN_BAT_EN, LOW);
+  }
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+  (void)adc_chars;
+  return s3MilliVolts * 2; // 1:2 divider, same as the calculation below
+#else
 
   // We will use the eFuse ADC calibration bits, to get accurate voltage
   // readings. The DFRobot FireBeetle Esp32-E V1.0's ADC is 12 bit, and uses
@@ -71,6 +91,7 @@ uint32_t readBatteryVoltage()
   // multiplied by 2.
   batteryVoltage *= 2;
   return batteryVoltage;
+#endif // CONFIG_IDF_TARGET_ESP32S3
 } // end readBatteryVoltage
 
 /* Returns battery percentage, rounded to the nearest integer.
@@ -1524,11 +1545,23 @@ const char *getWifiStatusPhrase(wl_status_t status)
  */
 void disableBuiltinLED()
 {
+#ifdef BOARD_RETERMINAL_E1002
+  // The XIAO module's LED_BUILTIN define is GPIO21, which on this board is
+  // the battery-measure enable pin -- holding it low breaks the battery
+  // reading. The E-series' actual user LED is GPIO6, inverted (LOW = on),
+  // so off means driving it HIGH.
+  pinMode(6, OUTPUT);
+  digitalWrite(6, HIGH);
+  gpio_hold_en(static_cast<gpio_num_t>(6));
+  gpio_deep_sleep_hold_en();
+  return;
+#else
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);
   gpio_hold_en(static_cast<gpio_num_t>(LED_BUILTIN));
   gpio_deep_sleep_hold_en();
   return;
+#endif // BOARD_RETERMINAL_E1002
 } // end disableBuiltinLED
 
 // Define the set of moon phase icon base on the chosen moon phase style

--- a/platformio/src/display_utils.cpp
+++ b/platformio/src/display_utils.cpp
@@ -1540,6 +1540,40 @@ const char *getWifiStatusPhrase(wl_status_t status)
   }
 } // end getWifiStatusPhrase
 
+/* Parks the microSD slot so that an inserted card cannot disturb the ePaper
+ * display.
+ *
+ * On the reTerminal E1002 the slot shares SCK and MOSI with the panel. This
+ * firmware never uses the card, so without this both SD control pins stay in
+ * their reset state as high-impedance inputs: the slot is left unpowered,
+ * and an inserted card then clamps the shared bus through the ESD protection
+ * diodes on its I/O pins, which conduct against its own dead supply rail.
+ * The panel stops seeing a valid logic high and never refreshes -- reported
+ * on the E1002 as "the screen is never refreshed if a micro SD card is
+ * plugged", with no card behaving normally.
+ *
+ * Powering the slot lets the card hold its inputs high-impedance as
+ * intended, and driving its chip select high keeps it from ever answering
+ * traffic meant for the panel. Neither pin is held through deep sleep, so
+ * the slot powers back down while asleep and sleep current is unchanged.
+ *
+ * Must run before any SPI activity, i.e. before the first initDisplay().
+ */
+void idleSDCard()
+{
+  if (PIN_SD_EN != PIN_UNUSED)
+  {
+    pinMode(PIN_SD_EN, OUTPUT);
+    digitalWrite(PIN_SD_EN, HIGH);
+  }
+  if (PIN_SD_CS != PIN_UNUSED)
+  {
+    pinMode(PIN_SD_CS, OUTPUT);
+    digitalWrite(PIN_SD_CS, HIGH);
+  }
+  return;
+} // end idleSDCard
+
 /* This function sets the builtin LED to LOW and disables it even during deep
  * sleep.
  */

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -37,6 +37,9 @@
 #if defined(SENSOR_BME680)
   #include <Adafruit_BME680.h>
 #endif
+#if defined(SENSOR_SHT4X)
+  #include <Adafruit_SHT4x.h>
+#endif
 #if defined(USE_HTTPS_WITH_CERT_VERIF) || defined(USE_HTTPS_WITH_CERT_VERIF)
   #include <WiFiClientSecure.h>
 #endif
@@ -290,8 +293,11 @@ void setup()
   killWiFi(); // WiFi no longer needed
 
   // GET INDOOR TEMPERATURE AND HUMIDITY, start BMEx80...
-  pinMode(PIN_BME_PWR, OUTPUT);
-  digitalWrite(PIN_BME_PWR, HIGH);
+  if (PIN_BME_PWR != PIN_UNUSED)
+  {
+    pinMode(PIN_BME_PWR, OUTPUT);
+    digitalWrite(PIN_BME_PWR, HIGH);
+  }
 #if defined(SENSOR_INIT_DELAY_MS) && SENSOR_INIT_DELAY_MS > 0
   delay(SENSOR_INIT_DELAY_MS);
 #endif
@@ -313,8 +319,25 @@ void setup()
   if(bme.begin(BME_ADDRESS))
   {
 #endif
+#if defined(SENSOR_SHT4X)
+  // Onboard SHT4x (reTerminal E-series). Fixed I2C address, event-based API.
+  Serial.print(String(TXT_READING_FROM) + " SHT4x... ");
+  Adafruit_SHT4x sht4;
+
+  if(sht4.begin(&I2C_bme))
+  {
+    sht4.setPrecision(SHT4X_HIGH_PRECISION);
+    sht4.setHeater(SHT4X_NO_HEATER);
+    sensors_event_t humEvent, tempEvent;
+    if (sht4.getEvent(&humEvent, &tempEvent))
+    {
+      inTemp     = tempEvent.temperature;       // Celsius
+      inHumidity = humEvent.relative_humidity;  // %
+    }
+#else
     inTemp     = bme.readTemperature(); // Celsius
     inHumidity = bme.readHumidity();    // %
+#endif
 
     // check if BME readings are valid
     // note: readings are checked again before drawing to screen. If a reading
@@ -322,7 +345,11 @@ void setup()
     //       displayed.
     if (std::isnan(inTemp) || std::isnan(inHumidity))
     {
+#if defined(SENSOR_SHT4X)
+      statusStr = "SHT4x " + String(TXT_READ_FAILED);
+#else
       statusStr = "BME " + String(TXT_READ_FAILED);
+#endif
       Serial.println(statusStr);
     }
     else
@@ -332,10 +359,17 @@ void setup()
   }
   else
   {
+#if defined(SENSOR_SHT4X)
+    statusStr = "SHT4x " + String(TXT_NOT_FOUND); // check wiring
+#else
     statusStr = "BME " + String(TXT_NOT_FOUND); // check wiring
+#endif
     Serial.println(statusStr);
   }
-  digitalWrite(PIN_BME_PWR, LOW);
+  if (PIN_BME_PWR != PIN_UNUSED)
+  {
+    digitalWrite(PIN_BME_PWR, LOW);
+  }
 
   String refreshTimeStr;
   getRefreshTimeStr(refreshTimeStr, timeConfigured, &timeInfo);

--- a/platformio/src/main.cpp
+++ b/platformio/src/main.cpp
@@ -138,6 +138,9 @@ void setup()
 #endif
 
   disableBuiltinLED();
+  // Before any SPI activity: an unparked microSD slot on the panel's bus
+  // stops the display refreshing whenever a card is inserted.
+  idleSDCard();
 
   // Open namespace for read/write to non-volatile storage
   prefs.begin(NVS_NAMESPACE, false);

--- a/platformio/src/renderer.cpp
+++ b/platformio/src/renderer.cpp
@@ -71,12 +71,12 @@
 #endif
 
 #ifdef DISP_7C_E6
-  GxEPD2_7C<GxEPD2_730c_GDEP073E01,
-            GxEPD2_730c_GDEP073E01::HEIGHT / 4> display(
-    GxEPD2_730c_GDEP073E01(PIN_EPD_CS,
-                           PIN_EPD_DC,
-                           PIN_EPD_RST,
-                           PIN_EPD_BUSY));
+  GxEPD2_7C<GxEPD2_730c_GDEP073E01_Patient,
+            GxEPD2_730c_GDEP073E01_Patient::HEIGHT / 4> display(
+    GxEPD2_730c_GDEP073E01_Patient(PIN_EPD_CS,
+                                   PIN_EPD_DC,
+                                   PIN_EPD_RST,
+                                   PIN_EPD_BUSY));
 #endif
 #ifndef ACCENT_COLOR
   #define ACCENT_COLOR GxEPD_BLACK
@@ -232,8 +232,11 @@ void drawMultiLnString(int16_t x, int16_t y, const String &text,
  */
 void initDisplay()
 {
-  pinMode(PIN_EPD_PWR, OUTPUT);
-  digitalWrite(PIN_EPD_PWR, HIGH);
+  if (PIN_EPD_PWR != PIN_UNUSED)
+  {
+    pinMode(PIN_EPD_PWR, OUTPUT);
+    digitalWrite(PIN_EPD_PWR, HIGH);
+  }
 #ifdef DRIVER_WAVESHARE
   display.init(115200, true, 2, false);
 #endif
@@ -263,7 +266,10 @@ void powerOffDisplay()
 {
   display.hibernate(); // turns powerOff() and sets controller to deep sleep for
                        // minimum power use
-  digitalWrite(PIN_EPD_PWR, LOW);
+  if (PIN_EPD_PWR != PIN_UNUSED)
+  {
+    digitalWrite(PIN_EPD_PWR, LOW);
+  }
   return;
 } // end initDisplay
 


### PR DESCRIPTION
The reTerminal E-series are all-in-one ESP32-S3 (XIAO module) e-paper devices: the E1002 has a 7.3in Spectra 6 panel (GDEP073E01, DISP_7C_E6) and the E1001 a 7.5in monochrome panel (GDEY075T7, DISP_BW_V2), both with an onboard SHT4x temperature/humidity sensor, battery, and enclosure.

New build environments seeed_reterminal_e1002 / seeed_reterminal_e1001 select the panel, sensor, and fixed internal pin mapping automatically via board flags -- no config edits needed. Supporting changes, all no-ops for existing boards:

- SENSOR_SHT4X indoor sensor option (Adafruit SHT4x library)
- battery voltage on ESP32-S3 via analogReadMilliVolts (the legacy esp_adc_cal path reads 0 there), plus a PIN_BAT_EN gate for boards whose battery divider sits behind an enable pin
- PIN_UNUSED sentinel to skip driving hardwired power pins
- the XIAO's LED_BUILTIN define is GPIO21, which the E-series uses as the battery-measure enable, so disableBuiltinLED drives the actual user LED (GPIO6, inverted) on these boards
- raised the GDEP073E01 busy timeout to 45s: some panel variants (the E1002's, for one) take ~28s for a full refresh and hit the stock 20s limit ("Busy Timeout!"); faster panels are unaffected
- Serial routed to UART0 (ARDUINO_USB_CDC_ON_BOOT=0) to reach the E-series' CH340 USB-serial bridge

Verified on reTerminal E1001 and E1002 hardware.